### PR TITLE
Do not use result of File::Spec->catfile for %INC lookup

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for inc-latest
 
 {{$NEXT}}
 
+    - Correctly short-circuit already-loaded modules on Win32
+
 0.500     2014-12-05 23:43:12-05:00 America/New_York
 
     - Split out from Module::Build into an independent package

--- a/lib/inc/latest/private.pm
+++ b/lib/inc/latest/private.pm
@@ -13,12 +13,13 @@ use IO::File;
 # so that the calling package is correct when $mod->import() runs.
 sub import {
     my ( $package, $mod, @args ) = @_;
-    my $file = $package->_mod2path($mod);
 
-    if ( $INC{$file} ) {
+    if ( $INC{ join( '/', split( /::/, $mod ) ) . '.pm' } ) {
         # Already loaded, but let _load_module handle import args
         goto \&_load_module;
     }
+
+    my $file = $package->_mod2path($mod);
 
     # A bundled copy must be present
     my ( $bundled, $bundled_dir ) = $package->_search_bundled($file)


### PR DESCRIPTION
No tests in repo, but the following seems to work ok:
`perl -MData::Dumper -l -Minc::latest::private=Data::Dumper -e 1`
