### PR TITLE
Silence warning

### DIFF
--- a/lib/inc/latest/private.pm
+++ b/lib/inc/latest/private.pm
@@ -31,6 +31,7 @@ sub import {
         goto \&_load_module;
     }
 
+    no warnings 'numeric';
     if ( _version($from_inc) >= _version($bundled) ) {
         # Ignore the bundled copy
         goto \&_load_module;


### PR DESCRIPTION
version strings may be not strictly numeric, resulting in errors similar to the following:

      Argument "0.21_01" isn't numeric in numeric ge (>=) at inc/latest/private.pm line 32.